### PR TITLE
refactor: replace requests with httpx and add utility modules

### DIFF
--- a/desktop_app.py
+++ b/desktop_app.py
@@ -9,7 +9,7 @@ import os
 import tkinter as tk
 from tkinter import ttk
 
-import requests
+import httpx
 
 from kezan.initializer import ensure_credentials
 from kezan.logger import get_logger
@@ -99,7 +99,7 @@ class KezanApp(tk.Tk):
     def fetch_data(self) -> None:
         params = {"limit": self.limit_var.get(), "min_margin": self.margin_var.get()}
         try:
-            resp = requests.get(API_URL, params=params, timeout=10)
+            resp = httpx.get(API_URL, params=params, timeout=10)
             resp.raise_for_status()
             data = resp.json()
         except Exception as exc:  # network or HTTP error

--- a/kezan/alerts.py
+++ b/kezan/alerts.py
@@ -1,0 +1,30 @@
+"""Simple threshold-based alert system."""
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any, Callable
+
+
+def check_margins(
+    items: Iterable[Dict[str, Any]],
+    threshold: float,
+    notifier: Callable[[str], None] | None = None,
+) -> None:
+    """Notify when an item's margin exceeds ``threshold``.
+
+    Parameters
+    ----------
+    items:
+        Iterable of item dictionaries that contain ``name`` and ``margin`` keys.
+    threshold:
+        Minimum margin (e.g. ``0.3`` for 30%) required to trigger a notification.
+    notifier:
+        Optional callable used to deliver messages.  Defaults to :func:`print`.
+    """
+    notify = notifier or print
+    alerts = (
+        f"{item.get('name', 'Unknown')} tiene un margen de {item.get('margin', 0)*100:.0f}%"
+        for item in items
+        if item.get("margin", 0) > threshold
+    )
+    for message in alerts:
+        notify(message)

--- a/kezan/context_memory.py
+++ b/kezan/context_memory.py
@@ -1,0 +1,28 @@
+"""Lightweight local context storage for previous analyses."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+
+_DEFAULT_PATH = Path.home() / ".kezan" / "context.json"
+
+
+def load_context(path: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Load stored analysis context."""
+    p = Path(path) if path else _DEFAULT_PATH
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def append_context(entry: Dict[str, Any], path: Optional[str] = None) -> None:
+    """Append a new analysis ``entry`` to the context store."""
+    data = load_context(path)
+    data.append(entry)
+    p = Path(path) if path else _DEFAULT_PATH
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2))

--- a/kezan/export.py
+++ b/kezan/export.py
@@ -1,0 +1,29 @@
+"""Utilities for exporting analysis results."""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Iterable, Dict, Any
+
+
+def export_data(items: Iterable[Dict[str, Any]], filename: str) -> None:
+    """Export ``items`` to ``filename``.
+
+    The format is determined by the file extension.  Supported formats are
+    ``.json`` and ``.csv``.
+    """
+    path = Path(filename)
+    if path.suffix.lower() == ".json":
+        path.write_text(json.dumps(list(items), ensure_ascii=False, indent=2))
+    elif path.suffix.lower() == ".csv":
+        items_iter = list(items)
+        if not items_iter:
+            path.write_text("")
+            return
+        with path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(items_iter[0].keys()))
+            writer.writeheader()
+            writer.writerows(items_iter)
+    else:
+        raise ValueError("Formato de exportación no soportado")

--- a/kezan/initializer.py
+++ b/kezan/initializer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Interactive initializer for Blizzard API credentials.
 
 This module provides helper functions to verify whether the Blizzard API
@@ -8,6 +6,8 @@ GUI dialogs or console input) to provide the necessary information and
 store it in a local ``.env`` file so that the rest of the application can
 load it using :mod:`python-dotenv`.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, Tuple

--- a/kezan/item_resolver.py
+++ b/kezan/item_resolver.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-try:
-    import requests
-except Exception:  # pragma: no cover - requests may not be installed
-    requests = None  # type: ignore
+import httpx
 
 from kezan.config import API_CLIENT_ID, API_CLIENT_SECRET, REGION
 
@@ -23,11 +20,9 @@ def _get_access_token() -> str:
     global _token_cache
     if _token_cache:
         return _token_cache
-    if requests is None:
-        raise RuntimeError("requests library is required")
     if not API_CLIENT_ID or not API_CLIENT_SECRET:
         raise RuntimeError("Las claves de la API de Blizzard no están configuradas.")
-    resp = requests.post(
+    resp = httpx.post(
         _TOKEN_URL,
         data={"grant_type": "client_credentials"},
         auth=(API_CLIENT_ID, API_CLIENT_SECRET),
@@ -55,7 +50,7 @@ def resolve_item_name(item_id: int) -> str:
         headers = {"Authorization": f"Bearer {token}"}
         params = {"namespace": _NAMESPACE, "locale": "en_US"}
         url = _ITEM_URL.format(item_id=item_id)
-        resp = requests.get(url, headers=headers, params=params, timeout=10)  # type: ignore[arg-type]
+        resp = httpx.get(url, headers=headers, params=params, timeout=10)
         resp.raise_for_status()
         name = resp.json().get("name")
         if name:

--- a/kezan/llm_interface.py
+++ b/kezan/llm_interface.py
@@ -3,7 +3,7 @@ import os
 import time
 from typing import List, Dict, Optional
 
-import requests
+import httpx
 import logging
 
 # Configuration for the local LLM endpoint
@@ -47,7 +47,7 @@ def analyze_items_with_llm(data: List[Dict]) -> str:
 
     try:
         start = time.perf_counter()
-        response = requests.post(LLM_API_URL, json=payload, timeout=30)
+        response = httpx.post(LLM_API_URL, json=payload, timeout=30)
         elapsed = time.perf_counter() - start
         response.raise_for_status()
         content = response.json().get("response", "").strip()
@@ -55,7 +55,7 @@ def analyze_items_with_llm(data: List[Dict]) -> str:
             raise RuntimeError("Respuesta vacía del modelo de IA.")
         logging.getLogger(__name__).info("LLM analysis took %.2fs", elapsed)
         return content
-    except requests.RequestException as exc:
+    except httpx.HTTPError as exc:
         raise RuntimeError(
             "El modelo de IA local no está activo o no responde."
         ) from exc
@@ -98,7 +98,7 @@ def analyze_recipes_with_llm(data: List[Dict], inventory: Optional[List[int]] = 
 
     try:
         start = time.perf_counter()
-        response = requests.post(LLM_API_URL, json=payload, timeout=30)
+        response = httpx.post(LLM_API_URL, json=payload, timeout=30)
         elapsed = time.perf_counter() - start
         response.raise_for_status()
         content = response.json().get("response", "").strip()
@@ -106,7 +106,7 @@ def analyze_recipes_with_llm(data: List[Dict], inventory: Optional[List[int]] = 
             raise RuntimeError("Respuesta vacía del modelo de IA.")
         logging.getLogger(__name__).info("LLM recipe analysis took %.2fs", elapsed)
         return content
-    except requests.RequestException as exc:  # pragma: no cover - network errors
+    except httpx.HTTPError as exc:  # pragma: no cover - network errors
         raise RuntimeError(
             "El modelo de IA local no está activo o no responde."
         ) from exc

--- a/kezan/recipes.py
+++ b/kezan/recipes.py
@@ -24,10 +24,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-try:  # pragma: no cover - requests might not be installed in tests
-    import requests
-except Exception:  # pragma: no cover
-    requests = None  # type: ignore
+import httpx
 
 from kezan.config import API_CLIENT_ID, API_CLIENT_SECRET, REGION
 
@@ -59,14 +56,12 @@ def load_recipes(profesion: str, json_file: str | None = None) -> List[Dict]:
         data = json.loads(Path(json_file).read_text())
         return data.get(profesion, [])
 
-    if requests is None:
-        raise RuntimeError("requests library is required for API access")
     if not API_CLIENT_ID or not API_CLIENT_SECRET:
         raise RuntimeError("Las claves de la API de Blizzard no están configuradas.")
 
     url = f"https://{REGION}.api.blizzard.com/data/wow/profession/{profesion}/recipes"
     try:
-        resp = requests.get(url, timeout=10)
+        resp = httpx.get(url, timeout=10)
         resp.raise_for_status()
         data = resp.json()
         return data.get("recipes", [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 fastapi
-requests
 httpx
 python-dotenv

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from kezan.alerts import check_margins
+
+
+def test_check_margins_notifies():
+    items = [
+        {"name": "A", "margin": 0.5},
+        {"name": "B", "margin": 0.1},
+    ]
+    messages: list[str] = []
+    check_margins(items, 0.3, notifier=messages.append)
+    assert messages == ["A tiene un margen de 50%"]

--- a/tests/test_analyzer_keyerror.py
+++ b/tests/test_analyzer_keyerror.py
@@ -1,5 +1,4 @@
 import asyncio
-import pytest
 import os
 import sys
 

--- a/tests/test_api_timeouts.py
+++ b/tests/test_api_timeouts.py
@@ -1,6 +1,5 @@
 import asyncio
 import httpx
-import pytest
 import os
 import sys
 

--- a/tests/test_context_memory.py
+++ b/tests/test_context_memory.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from kezan.context_memory import append_context, load_context
+
+
+def test_context_storage(tmp_path):
+    path = tmp_path / "ctx.json"
+    append_context({"x": 1}, path)
+    append_context({"x": 2}, path)
+    data = load_context(path)
+    assert [e["x"] for e in data] == [1, 2]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from kezan.export import export_data
+
+
+def test_export_json(tmp_path):
+    data = [{"a": 1}, {"a": 2}]
+    path = tmp_path / "out.json"
+    export_data(data, path)
+    assert path.exists()
+    assert "\n" in path.read_text()
+
+
+def test_export_csv(tmp_path):
+    data = [{"a": 1}, {"a": 2}]
+    path = tmp_path / "out.csv"
+    export_data(data, path)
+    content = path.read_text().splitlines()
+    assert content[0] == "a"
+    assert content[1] == "1"

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,8 +1,8 @@
 import os
 import sys
 
+import httpx
 import pytest
-import requests
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -20,7 +20,7 @@ def test_analyze_items_with_llm_success(monkeypatch):
     def fake_post(*args, **kwargs):
         return FakeResponse()
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
 
     result = analyze_items_with_llm([{"name": "Black Lotus"}])
     assert result == "ok"
@@ -28,9 +28,9 @@ def test_analyze_items_with_llm_success(monkeypatch):
 
 def test_analyze_items_with_llm_connection_error(monkeypatch):
     def fake_post(*args, **kwargs):
-        raise requests.ConnectionError("fail")
+        raise httpx.ConnectError("fail")
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
 
     with pytest.raises(RuntimeError) as exc:
         analyze_items_with_llm([{"name": "Black Lotus"}])

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -3,8 +3,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import kezan.recipes as recipes_module


### PR DESCRIPTION
## Summary
- reduce dependency footprint by removing `requests` in favor of `httpx`
- add alert, export and context memory utilities
- cover new features with unit tests and fix lint warnings

## Testing
- `ruff check kezan/initializer.py tests/test_analyzer_keyerror.py tests/test_api_timeouts.py tests/test_recipes.py tests/test_alerts.py tests/test_export.py tests/test_context_memory.py kezan/llm_interface.py kezan/item_resolver.py kezan/recipes.py desktop_app.py`
- `ruff check tests/test_alerts.py tests/test_export.py tests/test_context_memory.py`
- `ruff check tests/test_llm_interface.py`
- `ruff check kezan/alerts.py kezan/export.py kezan/context_memory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895835fb9b0832ab909e6407fe510bb