### PR TITLE
Add context limits, safe export, and changelog system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.3.0 - 2025-08-08 05:22:17
+Initial release of changelog system.
+

--- a/kezan/changelog.py
+++ b/kezan/changelog.py
@@ -1,0 +1,22 @@
+"""Simple CHANGELOG.md management utilities."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+
+def log_change(summary: str, version: str) -> None:
+    """Append a change entry to ``CHANGELOG.md``.
+
+    Each entry is stored in the format::
+
+        ## <version> - <timestamp>
+        <summary>
+    """
+    entry = (
+        f"## {version} - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        f"{summary.strip()}\n\n"
+    )
+    path = Path("CHANGELOG.md")
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(entry)

--- a/kezan/context_memory.py
+++ b/kezan/context_memory.py
@@ -1,28 +1,113 @@
-"""Lightweight local context storage for previous analyses."""
+"""Utilities for managing persistent analysis context.
+
+This module stores analysis context entries on disk using JSON.  To avoid
+unbounded growth it supports two pruning strategies that can be configured via
+environment variables:
+
+``CTX_MAX_ENTRIES``
+    Maximum number of entries to keep.  Older entries are discarded first.
+
+``CTX_MAX_DAYS``
+    Maximum age (in days) allowed for entries.  Older entries are removed.
+
+Entries are automatically timestamped and cleaned whenever the context is
+loaded or updated.  A helper is also provided to import context entries from a
+CSV file.
+"""
+
 from __future__ import annotations
 
+import csv
 import json
+import os
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 _DEFAULT_PATH = Path.home() / ".kezan" / "context.json"
 
 
+def _get_limits() -> tuple[int, int]:
+    """Return pruning limits from environment variables."""
+    max_entries = int(os.getenv("CTX_MAX_ENTRIES", "100"))
+    max_days = int(os.getenv("CTX_MAX_DAYS", "30"))
+    return max_entries, max_days
+
+
+def _clean(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Remove entries exceeding configured limits."""
+    max_entries, max_days = _get_limits()
+    if max_days > 0:
+        cutoff = datetime.utcnow() - timedelta(days=max_days)
+        cleaned: List[Dict[str, Any]] = []
+        for entry in data:
+            ts = entry.get("timestamp")
+            if not ts:
+                cleaned.append(entry)
+                continue
+            try:
+                if datetime.fromisoformat(ts) >= cutoff:
+                    cleaned.append(entry)
+            except ValueError:
+                cleaned.append(entry)
+        data = cleaned
+    if max_entries > 0 and len(data) > max_entries:
+        data = data[-max_entries:]
+    return data
+
+
 def load_context(path: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Load stored analysis context."""
+    """Load stored analysis context applying cleanup policies."""
     p = Path(path) if path else _DEFAULT_PATH
     if p.exists():
         try:
-            return json.loads(p.read_text())
+            data = json.loads(p.read_text())
         except json.JSONDecodeError:
-            return []
-    return []
+            data = []
+    else:
+        data = []
+    data = _clean(data)
+    if data:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    return data
 
 
 def append_context(entry: Dict[str, Any], path: Optional[str] = None) -> None:
     """Append a new analysis ``entry`` to the context store."""
+    entry = dict(entry)
+    entry.setdefault("timestamp", datetime.utcnow().isoformat())
     data = load_context(path)
     data.append(entry)
+    data = _clean(data)
     p = Path(path) if path else _DEFAULT_PATH
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def load_context_from_csv(csv_path: str, path: Optional[str] = None) -> None:
+    """Load context entries from a CSV file and merge them with existing data."""
+    dest = Path(path) if path else _DEFAULT_PATH
+    rows: List[Dict[str, Any]] = []
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            ts = row.get("timestamp")
+            if not ts:
+                continue
+            try:
+                datetime.fromisoformat(ts)
+            except ValueError:
+                continue
+            rows.append(row)
+    if not rows:
+        return
+    data = load_context(dest)
+    data.extend(rows)
+    data = _clean(data)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(data, ensure_ascii=False, indent=2))

--- a/kezan/export.py
+++ b/kezan/export.py
@@ -1,29 +1,64 @@
-"""Utilities for exporting analysis results."""
+"""Utilities for exporting analysis results with overwrite protection."""
 from __future__ import annotations
 
 import csv
 import json
+from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Dict, Any
+from typing import Any, Dict, Iterable
+
+from kezan.logger import get_logger
+
+logger = get_logger(__name__)
 
 
-def export_data(items: Iterable[Dict[str, Any]], filename: str) -> None:
+def export_data(
+    items: Iterable[Dict[str, Any]], filename: str, overwrite: bool = False
+) -> Path:
     """Export ``items`` to ``filename``.
 
-    The format is determined by the file extension.  Supported formats are
-    ``.json`` and ``.csv``.
+    Parameters
+    ----------
+    items:
+        Iterable with the data to export.
+    filename:
+        Target filename.  If a file with the same name already exists a
+        timestamp will be appended to avoid overwriting unless ``overwrite`` is
+        ``True``.
+    overwrite:
+        When ``True`` existing files are replaced.
+
+    Returns
+    -------
+    Path
+        Path to the file written to disk.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not ``.json`` or ``.csv``.
     """
+
     path = Path(filename)
+    if path.exists() and not overwrite:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        path = path.with_name(f"{path.stem}_{ts}{path.suffix}")
+
     if path.suffix.lower() == ".json":
-        path.write_text(json.dumps(list(items), ensure_ascii=False, indent=2))
+        items_iter = list(items)
+        path.write_text(json.dumps(items_iter, ensure_ascii=False, indent=2))
     elif path.suffix.lower() == ".csv":
         items_iter = list(items)
         if not items_iter:
             path.write_text("")
-            return
+            logger.info("Exported 0 records to %s", path)
+            return path
         with path.open("w", newline="", encoding="utf-8") as fh:
             writer = csv.DictWriter(fh, fieldnames=list(items_iter[0].keys()))
             writer.writeheader()
             writer.writerows(items_iter)
     else:
         raise ValueError("Formato de exportación no soportado")
+
+    logger.info("Exported %d records to %s", len(items_iter), path)
+    return path

--- a/kezan/formatter.py
+++ b/kezan/formatter.py
@@ -1,11 +1,13 @@
+"""Helpers for preparing item data for language model consumption."""
+
 from kezan.item_resolver import resolve_item_name
 
 
 def format_for_ai(items: list) -> dict:
     """Prepare item data for LLM consumption.
 
-    Ensures each item has a human readable name, falling back to a resolver
-    that queries the Blizzard API when necessary.
+    Ensures each item has a human readable name, falling back to a resolver that
+    queries the Blizzard API when necessary.
     """
     return {
         "items": [

--- a/kezan/version.py
+++ b/kezan/version.py
@@ -1,0 +1,11 @@
+"""Package version information."""
+__version__ = "1.3.0"
+
+
+def main() -> None:
+    """Print the current package version."""
+    print(__version__)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT)
+
+from kezan.changelog import log_change
+from kezan.version import __version__
+
+
+def test_log_change(tmp_path):
+    os.chdir(tmp_path)
+    log_change("initial entry", "0.1.0")
+    content = (tmp_path / "CHANGELOG.md").read_text()
+    assert "0.1.0" in content and "initial entry" in content
+
+
+def test_version_cli():
+    out = subprocess.check_output(
+        [sys.executable, "-m", "kezan.version"], cwd=ROOT
+    ).decode().strip()
+    assert out == __version__
+

--- a/tests/test_context_memory.py
+++ b/tests/test_context_memory.py
@@ -1,14 +1,42 @@
+import csv
+import json
 import os
 import sys
+from datetime import datetime, timedelta
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from kezan.context_memory import append_context, load_context
+from kezan.context_memory import append_context, load_context, load_context_from_csv
 
 
-def test_context_storage(tmp_path):
+def test_context_limit_entries(tmp_path, monkeypatch):
+    monkeypatch.setenv("CTX_MAX_ENTRIES", "2")
     path = tmp_path / "ctx.json"
     append_context({"x": 1}, path)
     append_context({"x": 2}, path)
+    append_context({"x": 3}, path)
     data = load_context(path)
-    assert [e["x"] for e in data] == [1, 2]
+    assert [e["x"] for e in data] == [2, 3]
+
+
+def test_context_age_cleanup(tmp_path, monkeypatch):
+    monkeypatch.setenv("CTX_MAX_DAYS", "7")
+    path = tmp_path / "ctx.json"
+    old = {"x": 1, "timestamp": (datetime.utcnow() - timedelta(days=10)).isoformat()}
+    new = {"x": 2, "timestamp": datetime.utcnow().isoformat()}
+    path.write_text(json.dumps([old, new], ensure_ascii=False))
+    data = load_context(path)
+    assert len(data) == 1 and data[0]["x"] == 2
+
+
+def test_load_context_from_csv(tmp_path):
+    json_path = tmp_path / "ctx.json"
+    csv_path = tmp_path / "ctx.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["timestamp", "x"])
+        writer.writeheader()
+        writer.writerow({"timestamp": datetime.utcnow().isoformat(), "x": "1"})
+        writer.writerow({"x": "2"})  # invalid, no timestamp
+    load_context_from_csv(csv_path, json_path)
+    data = load_context(json_path)
+    assert len(data) == 1 and data[0]["x"] == "1"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -21,3 +22,21 @@ def test_export_csv(tmp_path):
     content = path.read_text().splitlines()
     assert content[0] == "a"
     assert content[1] == "1"
+
+
+def test_export_protects_overwrite(tmp_path):
+    data = [{"a": 1}]
+    path = tmp_path / "out.json"
+    export_data(data, path)
+    second = export_data(data, path)
+    assert path.exists() and second.exists()
+    assert path != second
+
+
+def test_export_overwrite(tmp_path):
+    path = tmp_path / "out.json"
+    export_data([{"a": 1}], path)
+    export_data([{"a": 2}], path, overwrite=True)
+    content = json.loads(path.read_text())[0]["a"]
+    assert content == 2
+


### PR DESCRIPTION
## Summary
- limit stored context by entries and age with env-configurable cleaning and CSV import
- protect data exports with timestamped filenames and optional overwrite, plus logging
- add version module and simple changelog generator with entry for v1.3.0

## Testing
- `pytest`
- `pytest --cov=kezan`
- `pydocstyle kezan/context_memory.py kezan/export.py kezan/formatter.py kezan/recipes.py`


------
https://chatgpt.com/codex/tasks/task_e_6895884c9d44832abf256b9ca60c409f