### PR TITLE
Include httpx in PyInstaller build

### DIFF
--- a/KezanProtocol.spec
+++ b/KezanProtocol.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(
+    ['desktop_app.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['httpx'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='KezanProtocol',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='KezanProtocol',
+)

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ Los archivos resultantes se guardarán en el mismo directorio `docs/`.
 
 > ℹ️ El archivo `.env` **no** se incrusta en el binario; debe estar siempre junto al ejecutable.
 
+### Compilación manual desde el código fuente
+
+Si necesitas generar el ejecutable tú mismo y evitar errores como `ModuleNotFoundError: No module named 'httpx'`, instala PyInstaller e incluye la dependencia explícitamente:
+
+```bash
+pip install -r requirements.txt
+pip install pyinstaller
+python -m PyInstaller --noconfirm --onefile --windowed --name "KezanProtocol" --hidden-import=httpx desktop_app.py
+# o usando el archivo .spec incluido
+python -m PyInstaller KezanProtocol.spec
+```
+
 ## 💻 Uso
 
 1. Abre World of Warcraft.


### PR DESCRIPTION
## Summary
- add `KezanProtocol.spec` with `httpx` in `hiddenimports` for PyInstaller builds
- document how to compile the desktop app with the hidden import to prevent `ModuleNotFoundError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a7d5c6dc832a9b72e41c93e550ec