### PR TITLE
feat: improve offline access and LLM templates

### DIFF
--- a/installer/kezan_installer.nsi
+++ b/installer/kezan_installer.nsi
@@ -1,0 +1,27 @@
+; NSIS installer script for Kezan Protocol
+!include "MUI2.nsh"
+
+Name "Kezan Protocol"
+OutFile "KezanProtocolSetup.exe"
+InstallDir "$PROGRAMFILES\Kezan Protocol"
+
+Page Directory
+Page InstFiles
+
+Section "Install"
+    SetOutPath "$INSTDIR"
+    File "..\dist\KezanProtocol.exe"
+    CreateDirectory "$APPDATA\KezanProtocol"
+    CreateShortCut "$DESKTOP\Kezan Protocol.lnk" "$INSTDIR\KezanProtocol.exe"
+    CreateShortCut "$SMPROGRAMS\Kezan Protocol\Kezan Protocol.lnk" "$INSTDIR\KezanProtocol.exe"
+    WriteUninstaller "$INSTDIR\uninstall.exe"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Kezan Protocol" "DisplayName" "Kezan Protocol"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Kezan Protocol" "UninstallString" "$INSTDIR\uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+    Delete "$DESKTOP\Kezan Protocol.lnk"
+    RMDir /r "$SMPROGRAMS\Kezan Protocol"
+    RMDir /r "$INSTDIR"
+    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Kezan Protocol"
+SectionEnd

--- a/kezan/config.py
+++ b/kezan/config.py
@@ -10,6 +10,7 @@ It exposes four configuration constants that can be overridden via environment v
 - ``REALM_ID``: Connected realm ID for auction data.
 """
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 # Load environment variables from a .env file if present
@@ -20,3 +21,21 @@ API_CLIENT_ID = os.getenv("BLIZZ_CLIENT_ID", "")
 API_CLIENT_SECRET = os.getenv("BLIZZ_CLIENT_SECRET", "")
 REGION = os.getenv("REGION", "eu")
 REALM_ID = os.getenv("REALM_ID", "1080")  # Ejemplo: Sanguino
+
+# Path where local LLM templates are stored
+LOCAL_MODELS_PATH = os.getenv(
+    "LOCAL_MODELS_PATH", os.path.expanduser("~/.kezan/models")
+)
+
+
+def has_blizzard_credentials() -> bool:
+    """Return True if Blizzard API credentials are defined."""
+
+    return bool(API_CLIENT_ID and API_CLIENT_SECRET and REGION)
+
+
+def validate_local_model_path(path: str | None = None) -> bool:
+    """Validate that a local model directory exists."""
+
+    target = Path(path or LOCAL_MODELS_PATH)
+    return target.is_dir()

--- a/templates/llama-8b.json
+++ b/templates/llama-8b.json
@@ -1,0 +1,6 @@
+{
+  "model": "llama-8b",
+  "api_url": "http://localhost:11434/api/generate",
+  "temperature": 0.7,
+  "top_p": 0.9
+}


### PR DESCRIPTION
## Summary
- allow desktop app to run without Blizzard API credentials and warn user visually
- add classic menu bar and offline mode handling in UI
- support loading local LLM templates (initial LLaMA 8B) with configurable model path
- include NSIS installer script and sample LLaMA template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895afa3ea94832a9d1d99fd7a3ddf8c